### PR TITLE
Bump target version to SDK version 28

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,13 +19,10 @@ android {
     }
 }
 
-
 def supportLibraryVersion = '28.0.0'
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'junit:junit:4.12'
     implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
     implementation "com.android.support:design:$supportLibraryVersion"
-
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         applicationId "com.livefront.processkiller"
         minSdkVersion 21
-        targetSdkVersion 25
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
@@ -20,7 +20,7 @@ android {
 }
 
 
-def supportLibraryVersion = '25.1.0'
+def supportLibraryVersion = '28.0.0'
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])


### PR DESCRIPTION
Updates the target SDK version to 28 in anticipation of releasing to the Play Store, along with some cleanup to `build.gradle`.  There might be a follow-up PR to add a signing key if necessary.