### PR TITLE
Make Android 14 warning in the repo more prominent

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,8 +2,8 @@
 
 A simple app for testing application state saving and restoring.
 
-**Important Android 14 Update**
-Due to changes in the `ActivityManager.killBackgroundProcess` API, the app does not work on Android version 14.0 and above. See [ActivityManager docs](https://developer.android.com/reference/android/app/ActivityManager#killBackgroundProcesses(java.lang.String)) for more details.
+> [!CAUTION]
+> **Important Android 14 Update:** Due to changes in the `ActivityManager.killBackgroundProcess` API, the app does not work on Android version 14.0 and above. See [ActivityManager docs](https://developer.android.com/reference/android/app/ActivityManager#killBackgroundProcesses(java.lang.String)) for more details.
 
 <img src="art/process-killer-demo.gif" alt="Demo" width="400px">
 


### PR DESCRIPTION
This PR updates the Android 14 warning in the README to be more prominent. Note that I've chose "caution" but could use any of the other special types listed [here](https://github.com/orgs/community/discussions/16925) if more appropriate.

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/cfdedbbf-9ee0-4d0c-82fb-48445db38970"> | <img src="https://github.com/user-attachments/assets/44156640-002c-4d46-814d-937b470fa1c7"> |

