### PR TITLE
Update target SDK to 34

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-permission android:name="android.permission.KILL_BACKGROUND_PROCESSES" />
     <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS"
                      tools:ignore="ProtectedPermissions"/>
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
+                     tools:ignore="QueryAllPackagesPermission" />
 
     <application
         android:allowBackup="true"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # SDK Versions
 compileSdk = "34"
-targetSdk = "28"
+targetSdk = "34"
 minSdk = "21"
 
 # Dependency versions


### PR DESCRIPTION
This PR updates the target SDK to 34. This gets the app fully current and allows us to push new releases to Google Play (which currently requires a minimum target of 33). 

Note a couple of things: 

- We have to add the the `QUERY_ALL_PACKAGES` permission in order for the running apps to display properly after [changes introduces in Android 11](https://developer.android.com/training/package-visibility) that affect our use of `UsageStatsManager`.
- I have tested this and this change leaves the behavior the same for devices both pre and post Android 14: on devices prior to Android 14, the process-killing behavior still works and on devices with Android 14+ the process-killing behavior is still broken. So this is mainly just about getting up-to-date, rather than fixing anything.